### PR TITLE
Fixes problem for manager page

### DIFF
--- a/src/manager_page.php
+++ b/src/manager_page.php
@@ -152,7 +152,9 @@ if(!isset($_SESSION["u_id"])) {
 		die("Connection failed: " . $conn->connect_error);
 	}
 
-	$sql = "SELECT * FROM employee";
+    $sql = "SELECT user.f_name, user.l_name, employee.u_id, employee.salery
+            FROM employee
+            INNER JOIN user ON employee.u_id=user.u_id";
 
 	$result = $conn->query($sql);
 


### PR DESCRIPTION
When we moved the employees name from
the employee table to the user table
this page broke. The names of the
employees are now fetched from the
user table.

Issue #54